### PR TITLE
Development add: Only do CDC and de-dupe stages

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 pub const SLAB_SIZE_TARGET: usize = 4 * 1024 * 1024;
 
 pub struct Data {
+    skip_data: bool,
     seen: CuckooFilter,
     hashes: lru::LruCache<u32, ByHash>,
 
@@ -35,9 +36,18 @@ fn complete_slab_(slab: &mut SlabFile, buf: &mut Vec<u8>) -> Result<()> {
     Ok(())
 }
 
-pub fn complete_slab(slab: &mut SlabFile, buf: &mut Vec<u8>, threshold: usize) -> Result<bool> {
+pub fn complete_slab(
+    slab: &mut SlabFile,
+    buf: &mut Vec<u8>,
+    threshold: usize,
+    fake_write: bool,
+) -> Result<bool> {
     if buf.len() > threshold {
-        complete_slab_(slab, buf)?;
+        if fake_write {
+            buf.clear();
+        } else {
+            complete_slab_(slab, buf)?;
+        }
         Ok(true)
     } else {
         Ok(false)
@@ -53,15 +63,19 @@ impl Data {
         let seen = CuckooFilter::read(paths::index_path())?;
         let hashes = lru::LruCache::new(NonZeroUsize::new(slab_capacity).unwrap());
         let nr_slabs = data_file.get_nr_slabs() as u32;
+        let skip_data = std::env::var("BLK_ARCHIVE_DEVEL_SKIP_DATA").is_ok();
 
         {
-            let hashes_file = hashes_file.lock().unwrap();
-            assert_eq!(data_file.get_nr_slabs(), hashes_file.get_nr_slabs());
+            if !skip_data {
+                let hashes_file = hashes_file.lock().unwrap();
+                assert_eq!(data_file.get_nr_slabs(), hashes_file.get_nr_slabs());
+            }
         }
 
         let slabs = lru::LruCache::new(NonZeroUsize::new(slab_capacity).unwrap());
 
         Ok(Self {
+            skip_data: skip_data,
             seen,
             hashes,
             data_file,
@@ -137,7 +151,7 @@ impl Data {
     }
 
     fn complete_data_slab(&mut self) -> Result<()> {
-        if complete_slab(&mut self.data_file, &mut self.data_buf, 0)? {
+        if complete_slab(&mut self.data_file, &mut self.data_buf, 0, self.skip_data)? {
             let mut builder = IndexBuilder::with_capacity(1024); // FIXME: estimate properly
             std::mem::swap(&mut builder, &mut self.current_index);
             let buffer = builder.build()?;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -105,6 +105,7 @@ impl DedupHandler {
             &mut self.stream_file,
             &mut self.stream_buf,
             SLAB_SIZE_TARGET,
+            false,
         )?;
         Ok(())
     }
@@ -175,7 +176,7 @@ impl IoVecHandler for DedupHandler {
         builder.complete(&mut self.stream_buf)?;
         drop(builder);
 
-        complete_slab(&mut self.stream_file, &mut self.stream_buf, 0)?;
+        complete_slab(&mut self.stream_file, &mut self.stream_buf, 0, false)?;
         self.stream_file.close()?;
 
         Ok(())


### PR DESCRIPTION
This adds **BLK_ARCHIVE_DEVEL_SKIP_DATA** env.
During development, while enhancing the CDC and de-dupe check
it is beneficial to remove the IO for doing actual writes
of the data to the data slab.

Use **BLK_ARCHIVE_DEVEL_SKIP_DATA=1** to skip writing the data
to the data slab.  Everything else is done, to allow the
de-dupe functionality to work, as we need the hashes etc.
for the de-dupe.

**_NOTE: It should be very apparent that you cannot retrieve
any data from the archive when doing this!  This is
a development option that should not be used by normal
users._**

Extremely limited testing showing ...

```
skip_data=False (default)
elapsed          : 1.997
stream id        : d84df413c8256f16
file size        : 976.41M
mapped size      : 976.41M
total read       : 976.41M
fills size       : 731.41K
duplicate data   : 132.65M
data written     : 843.05M
stream written   : 6.05K
ratio            : 1.16
speed            : 488.94M/s
```
```bash
$ du -sh keep_data
843M    keep_data/
```
```
skip_data=True
elapsed          : 1.382
stream id        : 60c039f52aa9e5c3
file size        : 976.41M
mapped size      : 976.41M
total read       : 976.41M
fills size       : 731.41K
duplicate data   : 132.65M
data written     : 843.05M
stream written   : 6.05K
ratio            : 1.16
speed            : 706.52M/s
```
```bash
$ du -sh no_data
8.3M	no_data/
```

This simplistic change still encounters overhead for virtually everything, but writing the data to the slab data.  So we are saving the send->compressor thread->re-assemble->file IO with this.  I looked at a number of different options, but to selectively remove things from the execution path gets complicated quickly.